### PR TITLE
Add theme provider

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,12 +1,12 @@
-import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import RootStackNavigator from './navigators/RootStackNavigator';
+import ThemeProvider from './providers/ThemeProvider';
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <StatusBar style="auto" />
+    <ThemeProvider>
+      <StatusBar style={'auto'} />
       <RootStackNavigator />
-    </NavigationContainer>
+    </ThemeProvider>
   );
 }

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/providers/ThemeProvider.tsx
+++ b/providers/ThemeProvider.tsx
@@ -1,0 +1,30 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createContext, PropsWithChildren, useState } from 'react';
+import { useColorScheme } from 'react-native';
+import { PaperProvider } from 'react-native-paper';
+import { combinedDarkTheme, combinedLightTheme } from '../themes/theme';
+
+interface ContextValue {
+  colorMode: 'light' | 'dark' | 'auto';
+  setColorMode: (value: 'light' | 'dark' | 'auto') => void;
+}
+
+export const ThemeContext = createContext({} as ContextValue);
+
+export default function ThemeProvider({ children }: PropsWithChildren) {
+  const colorScheme = useColorScheme();
+  const [colorMode, setColorMode] = useState<'light' | 'dark' | 'auto'>('auto');
+
+  const theme =
+    colorMode === 'dark' || (colorMode === 'auto' && colorScheme === 'dark')
+      ? combinedDarkTheme
+      : combinedLightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ colorMode, setColorMode }}>
+      <PaperProvider theme={theme}>
+        <NavigationContainer theme={theme}>{children}</NavigationContainer>
+      </PaperProvider>
+    </ThemeContext.Provider>
+  );
+}

--- a/screens/CreateHouseholdScreen.tsx
+++ b/screens/CreateHouseholdScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { container, large } from '../themes/styles';
 
 export default function CreateHouseholdScreen() {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
 import { HomeStackParamList } from '../navigators/HomeStackNavigator';
 import { container, large } from '../themes/styles';
 
@@ -11,20 +12,26 @@ export default function HomeScreen({ navigation }: Props) {
     <View style={container}>
       <Text style={large}>Home screen</Text>
       <View style={s.tempHouseholdContainer}>
-        <Text style={s.tempHouseholdName}>Davidsson Household</Text>
+        <Text style={s.tempHouseholdName}>CodeDiddy Household</Text>
         <Button
-          title="Enter"
+          mode="elevated"
           onPress={() => navigation.replace('HouseholdNavigator')}
-        />
+        >
+          Enter
+        </Button>
       </View>
       <Button
-        title="Join Household"
+        mode="elevated"
         onPress={() => navigation.navigate('JoinHousehold')}
-      />
+      >
+        Join Household
+      </Button>
       <Button
-        title="Create Household"
+        mode="elevated"
         onPress={() => navigation.navigate('CreateHousehold')}
-      />
+      >
+        Create Household
+      </Button>
     </View>
   );
 }

--- a/screens/HouseholdScreen.tsx
+++ b/screens/HouseholdScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { container, large } from '../themes/styles';
 
 export default function HouseholdScreen() {

--- a/screens/JoinHouseholdScreen.tsx
+++ b/screens/JoinHouseholdScreen.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { container, large } from '../themes/styles';
 
 export default function JoinHouseholdScreen() {

--- a/screens/LoadingScreen.tsx
+++ b/screens/LoadingScreen.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Button, Image, View } from 'react-native';
+import { Image, View } from 'react-native';
+import { Button } from 'react-native-paper';
 import hushalletLogo from '../assets/logo/hushallet_logo.png';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
 import { container } from '../themes/styles';
@@ -15,9 +16,11 @@ export default function LoadingScreen({ navigation }: Props) {
         resizeMode="contain"
       />
       <Button
-        title="Go to Login"
+        mode="elevated"
         onPress={() => navigation.replace('Login')}
-      />
+      >
+        Go to Login
+      </Button>
     </View>
   );
 }

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Button, Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
 import { RootStackParamList } from '../navigators/RootStackNavigator';
 import { container, large } from '../themes/styles';
 
@@ -10,13 +11,17 @@ export default function LoginScreen({ navigation }: Props) {
     <View style={container}>
       <Text style={large}>Login screen</Text>
       <Button
-        title="Log in"
+        mode="elevated"
         onPress={() => navigation.replace('HomeNavigator')}
-      />
+      >
+        Log in
+      </Button>
       <Button
-        title="Register"
+        mode="elevated"
         onPress={() => navigation.navigate('Register')}
-      />
+      >
+        Register
+      </Button>
     </View>
   );
 }

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -1,4 +1,5 @@
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { container, large } from '../themes/styles';
 
 export default function RegisterScreen() {

--- a/screens/StatisticsScreen.tsx
+++ b/screens/StatisticsScreen.tsx
@@ -1,4 +1,5 @@
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { container, large } from '../themes/styles';
 
 export default function StatisticsScreen() {

--- a/themes/styles.ts
+++ b/themes/styles.ts
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native';
 export const { container, large } = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
     gap: 5, // Temporary solution to keep buttons apart

--- a/themes/theme.ts
+++ b/themes/theme.ts
@@ -1,1 +1,36 @@
-// TODO: Add dark and light mode here
+import {
+  DarkTheme as NavigationDarkTheme,
+  DefaultTheme as NavigationLightTheme,
+  Theme,
+} from '@react-navigation/native';
+import {
+  adaptNavigationTheme,
+  MD3DarkTheme,
+  MD3LightTheme,
+} from 'react-native-paper';
+import { ThemeProp } from 'react-native-paper/lib/typescript/types';
+
+const { LightTheme, DarkTheme } = adaptNavigationTheme({
+  reactNavigationLight: NavigationLightTheme,
+  reactNavigationDark: NavigationDarkTheme,
+});
+
+export type AppTheme = ThemeProp & Theme;
+
+export const combinedLightTheme: AppTheme = {
+  ...MD3LightTheme,
+  ...LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    ...LightTheme.colors,
+  },
+};
+
+export const combinedDarkTheme: AppTheme = {
+  ...MD3DarkTheme,
+  ...DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    ...DarkTheme.colors,
+  },
+};


### PR DESCRIPTION
* Configured expo go to not always use light mode regardless of device settings
* Added theme provider, and combined themes, with support for light, dark and auto mode
* Updated imports and refactored to use paper instead of native components (button and text)