### PR TITLE
Disabled login/register button while loading is true

### DIFF
--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -102,8 +102,8 @@ export default function LoginScreen({ navigation }: Props) {
                   icon="login"
                   mode="contained"
                   onPress={handleLogin}
+                  disabled={loading}
                 >
-                  {/* Log In */}
                   {loading ? 'Logging in...' : 'Log In'}
                 </Button>
                 <View style={authStyles.linkTextContainer}>

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -92,6 +92,7 @@ const RegisterScreen = ({ navigation }: Props) => {
                 icon="login"
                 mode="contained"
                 onPress={handleRegister}
+                disabled={loading}
               >
                 {loading ? 'Trying to Register..' : 'Register'}
               </Button>


### PR DESCRIPTION
Button now gets disabled after pressing log in or register while the request is still being processed, to prevent multiple requests